### PR TITLE
Initial setup for a SteamVR C++ driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.10)
+project(OpenVRDriverExample LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# --- OpenVR SDK ---
+# Expect OpenVR to be cloned into a subdirectory named 'openvr'
+# or provide its location via -DOpenVR_ROOT_DIR=<path_to_openvr_sdk>
+find_package(OpenVR REQUIRED)
+
+if(NOT OpenVR_FOUND)
+    message(FATAL_ERROR "OpenVR SDK not found. Please clone it into an 'openvr' subdirectory or specify OpenVR_ROOT_DIR.")
+endif()
+
+include_directories(${OpenVR_INCLUDE_DIR})
+
+# --- Driver ---
+# Add our driver as a library
+add_library(MyDriver SHARED driver/src/driver_main.cpp driver/include/driver_main.h)
+
+# Link our driver against OpenVR
+target_link_libraries(MyDriver PRIVATE ${OpenVR_LIBRARIES})
+
+# --- Output ---
+# Define where the driver binary should be placed
+# For example, in a 'bin' directory within the build folder
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+# --- Platform Specifics ---
+if(WIN32)
+    # Windows specific settings
+    target_compile_definitions(MyDriver PRIVATE TDC_WINDOWS)
+    # Ensure the output name is just 'driver_mydriver.dll' as SteamVR might expect
+    set_target_properties(MyDriver PROPERTIES PREFIX "" OUTPUT_NAME "driver_mydriver")
+elseif(LINUX)
+    # Linux specific settings
+    target_compile_definitions(MyDriver PRIVATE TDC_LINUX)
+    set_target_properties(MyDriver PROPERTIES PREFIX "lib" OUTPUT_NAME "driver_mydriver")
+    target_link_options(MyDriver PRIVATE "-Wl,-Bsymbolic") # Recommended for OpenVR drivers on Linux
+elseif(APPLE)
+    # macOS specific settings
+    target_compile_definitions(MyDriver PRIVATE TDC_MACOSX)
+    set_target_properties(MyDriver PROPERTIES PREFIX "lib" OUTPUT_NAME "driver_mydriver")
+    # Add other macOS specific settings if needed
+endif()
+
+message(STATUS "OpenVR Include directory: ${OpenVR_INCLUDE_DIR}")
+message(STATUS "OpenVR Libraries: ${OpenVR_LIBRARIES}")
+message(STATUS "Driver output directory: ${CMAKE_BINARY_DIR}/bin")

--- a/README.md
+++ b/README.md
@@ -1,3 +1,87 @@
-# UVGS
+# OpenVR Driver Example
 
-Universal Virtual Gunstock for SteamVR
+This repository contains an example of a C++ SteamVR driver.
+
+## Prerequisites
+
+*   **CMake:** Version 3.10 or higher.
+*   **C++ Compiler:** A C++17 compatible compiler (e.g., GCC, Clang, MSVC).
+*   **Git:** For cloning this repository and the OpenVR SDK.
+*   **SteamVR:** Installed and configured.
+
+## Setup and Building
+
+1.  **Clone this Repository:**
+    ```bash
+    git clone <repository_url> OpenVRDriverExample
+    cd OpenVRDriverExample
+    ```
+    (Replace `<repository_url>` with the actual URL of this repository)
+
+2.  **Clone the OpenVR SDK:**
+    The driver requires the OpenVR SDK. Clone it into a subdirectory named `openvr` within the `OpenVRDriverExample` directory:
+    ```bash
+    git clone https://github.com/ValveSoftware/openvr.git openvr
+    ```
+    If you clone it to a different location, you will need to specify the path to CMake using `-DOpenVR_ROOT_DIR=<path_to_openvr_sdk>`.
+
+3.  **Configure and Build with CMake:**
+    Create a build directory and run CMake:
+    ```bash
+    mkdir build
+    cd build
+    cmake ..
+    # If OpenVR is not in the 'openvr' subdirectory:
+    # cmake .. -DOpenVR_ROOT_DIR=/path/to/your/openvr/sdk
+    ```
+    Then, compile the driver:
+    ```bash
+    cmake --build . --config Release
+    ```
+    The compiled driver binary (e.g., `driver_mydriver.dll` on Windows, `libdriver_mydriver.so` on Linux) will be located in the `build/bin` directory.
+
+## Installation in SteamVR
+
+To use this driver with SteamVR, you need to tell SteamVR where to find it.
+
+1.  **Locate your SteamVR Drivers Directory:**
+    This is typically found within your Steam installation:
+    *   Windows: `C:\Program Files (x86)\Steam\steamapps\common\SteamVR\drivers`
+    *   Linux: `~/.steam/steam/steamapps/common/SteamVR/drivers`
+    *   macOS: `~/Library/Application Support/Steam/steamapps/common/SteamVR/drivers` (Path may vary)
+
+2.  **Create a Directory for Your Driver:**
+    Inside the SteamVR `drivers` directory, create a new folder for your driver (e.g., `mydriver`).
+    ```bash
+    # Example for Linux:
+    # mkdir -p ~/.steam/steam/steamapps/common/SteamVR/drivers/mydriver/bin
+    ```
+    You will need to create a `bin` subdirectory inside your driver's folder as specified in the `driver.vrdrivermanifest`.
+
+3.  **Copy Driver Files:**
+    *   Copy the `driver.vrdrivermanifest` file from `OpenVRDriverExample/driver/driver.vrdrivermanifest` to the `mydriver` directory you just created (e.g., `~/.steam/steam/steamapps/common/SteamVR/drivers/mydriver/`).
+    *   Copy the compiled driver binary (e.g., `driver_mydriver.dll`, `libdriver_mydriver.so`) from your `OpenVRDriverExample/build/bin/` directory to the `bin` subdirectory you created (e.g., `~/.steam/steam/steamapps/common/SteamVR/drivers/mydriver/bin/`).
+
+    Your installed driver structure should look something like this:
+    ```
+    SteamVR/
+    └── drivers/
+        └── mydriver/
+            ├── driver.vrdrivermanifest
+            └── bin/
+                └── driver_mydriver.dll  (or .so, .dylib)
+    ```
+
+4.  **Restart SteamVR:**
+    If SteamVR was running, restart it. It should now attempt to load your driver.
+
+## Driver Details
+
+*   **Driver Name:** `mydriver` (as specified in `driver.vrdrivermanifest`)
+*   **Output Binary:** `driver_mydriver` (e.g., `driver_mydriver.dll`, `libdriver_mydriver.so`)
+
+## Troubleshooting
+
+*   Check the SteamVR logs for messages related to driver loading. These can be found in `Steam\logs\vrserver.txt` or `~/.steam/steam/logs/vrserver.txt`.
+*   Ensure that the paths in `driver.vrdrivermanifest` correctly point to your driver binary relative to the manifest file's location.
+*   Verify that your compiler and CMake are correctly configured and that the OpenVR SDK was found during the CMake configuration step.

--- a/driver/driver.vrdrivermanifest
+++ b/driver/driver.vrdrivermanifest
@@ -1,0 +1,11 @@
+{
+    "manifest_version": 1,
+    "driver_name": "mydriver",
+    "driver_version": "0.0.1",
+    "binaries": {
+        "win64": "bin/driver_mydriver.dll",
+        "linux64": "bin/libdriver_mydriver.so",
+        "osx": "bin/libdriver_mydriver.dylib"
+    },
+    "driver_type": "server"
+}

--- a/driver/include/driver_main.h
+++ b/driver/include/driver_main.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <openvr_driver.h>
+
+class MyTrackedDeviceProvider : public vr::IServerTrackedDeviceProvider
+{
+public:
+    virtual vr::EVRInitError Init(vr::IVRDriverContext *pDriverContext) override;
+    virtual void Cleanup() override;
+    virtual const char * const *GetInterfaceVersions() override;
+    virtual void RunFrame() override;
+    virtual bool ShouldBlockStandby() override;
+    virtual void EnterStandby() override;
+    virtual void LeaveStandby() override;
+};

--- a/driver/src/driver_main.cpp
+++ b/driver/src/driver_main.cpp
@@ -1,0 +1,90 @@
+#include "driver_main.h"
+
+#include <openvr_driver.h>
+#include <vector> // Required for GetInterfaceVersions
+
+// Global entry point
+vr::IServerTrackedDeviceProvider *g_pMyDriverProvider = nullptr;
+
+// HMD_DLL_EXPORT void *HmdDriverFactory(const char *pInterfaceName, int *pReturnCode)
+// {
+//     if (0 == strcmp(vr::IServerTrackedDeviceProvider_Version, pInterfaceName))
+//     {
+//         if (!g_pMyDriverProvider) {
+//             g_pMyDriverProvider = new MyTrackedDeviceProvider();
+//         }
+//         return g_pMyDriverProvider;
+//     }
+
+//     if (pReturnCode)
+//         *pReturnCode = vr::VRInitError_Init_InterfaceNotFound;
+
+//     return NULL;
+// }
+
+
+// Implementation of IServerTrackedDeviceProvider methods
+vr::EVRInitError MyTrackedDeviceProvider::Init(vr::IVRDriverContext *pDriverContext)
+{
+    VR_INIT_SERVER_DRIVER_CONTEXT(pDriverContext);
+    // TODO: Initialize your tracked devices here
+    return vr::VRInitError_None;
+}
+
+void MyTrackedDeviceProvider::Cleanup()
+{
+    VR_CLEANUP_SERVER_DRIVER_CONTEXT();
+    // TODO: Cleanup your tracked devices here
+    g_pMyDriverProvider = nullptr; // Ensure we reset the global pointer
+}
+
+const char * const *MyTrackedDeviceProvider::GetInterfaceVersions()
+{
+    static const char * const versions[] = { vr::IServerTrackedDeviceProvider_Version, nullptr };
+    return versions;
+}
+
+void MyTrackedDeviceProvider::RunFrame()
+{
+    // TODO: Update device poses or states here
+}
+
+bool MyTrackedDeviceProvider::ShouldBlockStandby()
+{
+    return false;
+}
+
+void MyTrackedDeviceProvider::EnterStandby()
+{
+}
+
+void MyTrackedDeviceProvider::LeaveStandby()
+{
+}
+
+// Global entry point function
+#if defined(_WIN32)
+#define HMD_DLL_EXPORT extern "C" __declspec( dllexport )
+#elif defined(__GNUC__) || defined(COMPILER_GCC) || defined(__APPLE__)
+#define HMD_DLL_EXPORT extern "C" __attribute__((visibility("default")))
+#else
+#error "Unsupported Platform."
+#endif
+
+HMD_DLL_EXPORT void *HmdDriverFactory(const char *pInterfaceName, int *pReturnCode)
+{
+    if (0 == strcmp(vr::IServerTrackedDeviceProvider_Version, pInterfaceName))
+    {
+        if (!g_pMyDriverProvider) { // Check if already instantiated
+            g_pMyDriverProvider = new MyTrackedDeviceProvider();
+        }
+        if (pReturnCode)
+            *pReturnCode = vr::VRInitError_None; // Set to None explicitly on success
+        return g_pMyDriverProvider;
+    }
+
+    if (pReturnCode)
+        *pReturnCode = vr::VRInitError_Init_InterfaceNotFound;
+
+    return NULL;
+}


### PR DESCRIPTION
This commit introduces the basic structure for a SteamVR driver using the OpenVR SDK.

It includes:
- A minimal IServerTrackedDeviceProvider implementation.
- CMake build system for compiling the driver.
- A driver.vrdrivermanifest file for SteamVR integration.
- Updated README.md with instructions for cloning OpenVR, building, and installing the driver.

The OpenVR SDK itself is not included in this repository and must be cloned manually by you as per the README instructions, due to limitations in the development environment preventing direct git cloning.