### PR TITLE
Fix: Improve OpenVR SDK detection in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,16 +8,28 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Expect OpenVR to be cloned into a subdirectory named 'openvr'
 # or provide its location via -DOpenVR_ROOT_DIR=<path_to_openvr_sdk>
 
-# Add OpenVR's cmake directory to the module path so find_package can locate FindOpenVR.cmake
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/openvr/cmake")
-# Also, set OpenVR_DIR to point to the SDK's root, as FindOpenVR.cmake might use it.
-# This assumes the user has cloned 'openvr' into the project root.
-set(OpenVR_DIR ${CMAKE_CURRENT_SOURCE_DIR}/openvr)
+set(OpenVR_SDK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/openvr) # Define once
+set(OpenVR_CMAKE_MODULE_PATH ${OpenVR_SDK_DIR}/cmake)
+
+# Check if the expected FindOpenVR.cmake exists
+if(NOT EXISTS "${OpenVR_CMAKE_MODULE_PATH}/FindOpenVR.cmake")
+    message(FATAL_ERROR "OpenVR SDK not found or incomplete in the 'openvr' subdirectory. \n"
+                        "Please clone the OpenVR SDK from GitHub (https://github.com/ValveSoftware/openvr) \n"
+                        "into the 'openvr' directory at the root of this project. \n"
+                        "Expected path: ${OpenVR_CMAKE_MODULE_PATH}/FindOpenVR.cmake was not found.")
+endif()
+
+# Add OpenVR's cmake directory to the module path
+list(APPEND CMAKE_MODULE_PATH "${OpenVR_CMAKE_MODULE_PATH}")
+# Set OpenVR_DIR to point to the SDK's root
+set(OpenVR_DIR ${OpenVR_SDK_DIR})
 
 find_package(OpenVR REQUIRED)
 
+# This check is somewhat redundant now due to the manual check above and REQUIRED in find_package,
+# but it's good practice to keep it.
 if(NOT OpenVR_FOUND)
-    message(FATAL_ERROR "OpenVR SDK not found. Please clone it into an 'openvr' subdirectory or specify OpenVR_ROOT_DIR.")
+    message(FATAL_ERROR "find_package(OpenVR REQUIRED) failed even after locating FindOpenVR.cmake. Check OpenVR SDK integrity and CMake logs.")
 endif()
 
 include_directories(${OpenVR_INCLUDE_DIR})


### PR DESCRIPTION
The CMake configuration would fail with an opaque error if the OpenVR SDK was not found in the expected 'openvr' subdirectory.

This change modifies `CMakeLists.txt` to:
1. Explicitly check for the presence of `openvr/cmake/FindOpenVR.cmake`.
2. If not found, issue a FATAL_ERROR with clear instructions for you to clone the OpenVR SDK from GitHub into the 'openvr' subdirectory.

This makes the build process more robust and user-friendly by providing actionable feedback when prerequisites are missing. The `README.md` already contains instructions for cloning the SDK, and this change reinforces that guidance directly within the CMake process.