### PR TITLE
feat: Implement physical controller pose tracking for virtual control…

### DIFF
--- a/driver/include/driver_main.h
+++ b/driver/include/driver_main.h
@@ -12,6 +12,10 @@ class MyTrackedDeviceProvider : public vr::IServerTrackedDeviceProvider { // Add
   MyTrackedDeviceProvider(); // Added constructor
   virtual ~MyTrackedDeviceProvider(); // Added destructor
 
+  // Member variables to store device indices
+  uint32_t m_unLeftControllerDeviceIndex;
+  uint32_t m_unRightControllerDeviceIndex;
+
   virtual vr::EVRInitError Init(vr::IVRDriverContext* pDriverContext) override;
   virtual void Cleanup() override;
   virtual const char* const* GetInterfaceVersions() override;
@@ -23,6 +27,7 @@ class MyTrackedDeviceProvider : public vr::IServerTrackedDeviceProvider { // Add
  private: // Added private section
   std::unique_ptr<MyControllerDriver> left_controller_;
   std::unique_ptr<MyControllerDriver> right_controller_;
+
 };
 
 }  // namespace vr // Added namespace

--- a/driver/include/my_controller_driver.h
+++ b/driver/include/my_controller_driver.h
@@ -9,6 +9,9 @@ class MyControllerDriver : public vr::ITrackedDeviceServerDriver {
   MyControllerDriver();
   virtual ~MyControllerDriver();
 
+  // Method to set the physical controller index
+  void SetPhysicalControllerIndex(uint32_t index);
+
   // Inherited via ITrackedDeviceServerDriver
   virtual vr::EVRInitError Activate(uint32_t unObjectId) override;
   virtual void Deactivate() override;
@@ -22,6 +25,8 @@ class MyControllerDriver : public vr::ITrackedDeviceServerDriver {
 
  private:
   uint32_t m_unObjectId; // Store the object ID
+  uint32_t m_unPhysicalControllerIndex; // Store the index of the physical controller
+  vr::DriverPose_t m_lastPose; // Stores the last known pose of the controller
 };
 
 }  // namespace vr

--- a/driver/src/driver_main.cpp
+++ b/driver/src/driver_main.cpp
@@ -3,6 +3,7 @@
 #include <openvr_driver.h>
 #include <vector> // Required for GetInterfaceVersions
 #include "my_controller_driver.h" // Include the controller driver
+#include "vrcommon/shared/driverlog.h" // For VRDriverLog
 
 // Define the vr namespace
 namespace vr {
@@ -11,36 +12,93 @@ namespace vr {
 vr::IServerTrackedDeviceProvider *g_pMyDriverProvider = nullptr;
 
 // MyTrackedDeviceProvider methods
-MyTrackedDeviceProvider::MyTrackedDeviceProvider() {} // Constructor
+MyTrackedDeviceProvider::MyTrackedDeviceProvider()
+    : m_unLeftControllerDeviceIndex(vr::k_unTrackedDeviceIndexInvalid),
+      m_unRightControllerDeviceIndex(vr::k_unTrackedDeviceIndexInvalid) {} // Constructor
 MyTrackedDeviceProvider::~MyTrackedDeviceProvider() {} // Destructor
 
 // Implementation of IServerTrackedDeviceProvider methods
 vr::EVRInitError MyTrackedDeviceProvider::Init(vr::IVRDriverContext *pDriverContext)
 {
     VR_INIT_SERVER_DRIVER_CONTEXT(pDriverContext);
+    VRDriverLog()->Log("MyTrackedDeviceProvider::Init - Starting initialization");
 
-    // Initialize your tracked devices here
-    left_controller_ = std::make_unique<MyControllerDriver>();
-    if (left_controller_) {
-        vr::VRServerDriverHost()->TrackedDeviceAdded("my_left_controller_serial", vr::TrackedDeviceClass_Controller, left_controller_.get());
+    uint32_t trackedDeviceCount = vr::VRServerDriverHost()->GetTrackedDeviceCount();
+    VRDriverLog()->Log("MyTrackedDeviceProvider::Init - Total tracked devices found by OpenVR: " + std::to_string(trackedDeviceCount));
+
+    // Iterate through connected devices to find controllers
+    for (uint32_t i = 0; i < trackedDeviceCount; ++i) {
+        vr::PropertyContainerHandle_t container = vr::VRProperties()->TrackedDeviceToPropertyContainer(i);
+
+        ETrackedPropertyError propError; // Renamed to avoid conflict
+        int32_t device_class = vr::VRProperties()->GetInt32Property(container, vr::Prop_DeviceClass_Int32, &propError);
+
+        if (propError != vr::TrackedProp_Success) {
+            VRDriverLog()->Log("MyTrackedDeviceProvider::Init - Error getting DeviceClass for device index " + std::to_string(i) + ": " + std::to_string(propError));
+            continue;
+        }
+
+        if (device_class == vr::TrackedDeviceClass_Controller) {
+            int32_t controller_role = vr::VRProperties()->GetInt32Property(container, vr::Prop_ControllerRoleHint_Int32, &propError);
+
+            if (propError != vr::TrackedProp_Success) {
+                VRDriverLog()->Log("MyTrackedDeviceProvider::Init - Error getting ControllerRoleHint for device index " + std::to_string(i) + ": " + std::to_string(propError));
+                continue;
+            }
+
+            if (controller_role == vr::TrackedControllerRole_LeftHand) {
+                if (!left_controller_) { // Initialize only if not already done
+                    VRDriverLog()->Log("MyTrackedDeviceProvider::Init - Found Left Hand controller at OpenVR index: " + std::to_string(i));
+                    left_controller_ = std::make_unique<MyControllerDriver>();
+                    vr::EVRInitError addError = vr::VRServerDriverHost()->TrackedDeviceAdded("my_left_controller_serial", vr::TrackedDeviceClass_Controller, left_controller_.get());
+                    if (addError == vr::VRInitError_None) {
+                        VRDriverLog()->Log("MyTrackedDeviceProvider::Init - Successfully added left controller.");
+                        m_unLeftControllerDeviceIndex = i; // Store the device index
+                        left_controller_->SetPhysicalControllerIndex(i); // Set the physical index
+                    } else {
+                        VRDriverLog()->Log("MyTrackedDeviceProvider::Init - Error adding left controller: " + std::to_string(addError));
+                        left_controller_.reset(); // Nullify if not added
+                    }
+                }
+            } else if (controller_role == vr::TrackedControllerRole_RightHand) {
+                if (!right_controller_) { // Initialize only if not already done
+                    VRDriverLog()->Log("MyTrackedDeviceProvider::Init - Found Right Hand controller at OpenVR index: " + std::to_string(i));
+                    right_controller_ = std::make_unique<MyControllerDriver>();
+                    vr::EVRInitError addError = vr::VRServerDriverHost()->TrackedDeviceAdded("my_right_controller_serial", vr::TrackedDeviceClass_Controller, right_controller_.get());
+                    if (addError == vr::VRInitError_None) {
+                        VRDriverLog()->Log("MyTrackedDeviceProvider::Init - Successfully added right controller.");
+                        m_unRightControllerDeviceIndex = i; // Store the device index
+                        right_controller_->SetPhysicalControllerIndex(i); // Set the physical index
+                    } else {
+                        VRDriverLog()->Log("MyTrackedDeviceProvider::Init - Error adding right controller: " + std::to_string(addError));
+                        right_controller_.reset(); // Nullify if not added
+                    }
+                }
+            }
+        }
     }
 
-    right_controller_ = std::make_unique<MyControllerDriver>();
-    if (right_controller_) {
-        vr::VRServerDriverHost()->TrackedDeviceAdded("my_right_controller_serial", vr::TrackedDeviceClass_Controller, right_controller_.get());
+    if (!left_controller_) {
+        VRDriverLog()->Log("MyTrackedDeviceProvider::Init - No physical left controller found/initialized.");
+    }
+    if (!right_controller_) {
+        VRDriverLog()->Log("MyTrackedDeviceProvider::Init - No physical right controller found/initialized.");
     }
 
+    VRDriverLog()->Log("MyTrackedDeviceProvider::Init - Finished initialization");
     return vr::VRInitError_None;
 }
 
 void MyTrackedDeviceProvider::Cleanup()
 {
+    VRDriverLog()->Log("MyTrackedDeviceProvider::Cleanup - Called");
     VR_CLEANUP_SERVER_DRIVER_CONTEXT();
     // Cleanup your tracked devices here
     // unique_ptr will automatically clean up the controller objects
     left_controller_.reset();
     right_controller_.reset();
-    // g_pMyDriverProvider = nullptr; // This is handled by the caller or at a higher level
+    g_pMyDriverProvider = nullptr; // Explicitly nullify the global pointer
+    VRDriverLog()->Log("MyTrackedDeviceProvider::Cleanup - Finished");
 }
 
 const char * const *MyTrackedDeviceProvider::GetInterfaceVersions()
@@ -49,8 +107,14 @@ const char * const *MyTrackedDeviceProvider::GetInterfaceVersions()
     return versions;
 }
 
+// Define a preprocessor macro for verbose logging control, e.g., in a common header or at the top of the file
+// #define ENABLE_VERBOSE_RUNFRAME_LOGGING
+
 void MyTrackedDeviceProvider::RunFrame()
 {
+#ifdef ENABLE_VERBOSE_RUNFRAME_LOGGING
+    VRDriverLog()->Log("MyTrackedDeviceProvider::RunFrame - Called");
+#endif
     // Update device poses or states here
     if (left_controller_) {
         left_controller_->RunFrame();
@@ -58,6 +122,11 @@ void MyTrackedDeviceProvider::RunFrame()
     if (right_controller_) {
         right_controller_->RunFrame();
     }
+    // It might be useful to log if controllers are not present, but could be spammy.
+    // Example:
+    // if (!left_controller_ && !right_controller_) {
+    //     VRDriverLog()->Log("MyTrackedDeviceProvider::RunFrame - No controllers to update.");
+    // }
 }
 
 bool MyTrackedDeviceProvider::ShouldBlockStandbyMode()
@@ -89,13 +158,17 @@ HMD_DLL_EXPORT void *HmdDriverFactory(const char *pInterfaceName, int *pReturnCo
     if (0 == strcmp(vr::IServerTrackedDeviceProvider_Version, pInterfaceName))
     {
         if (!vr::g_pMyDriverProvider) { // Check if already instantiated
+            VRDriverLog()->Log("HmdDriverFactory - Creating new MyTrackedDeviceProvider instance.");
             vr::g_pMyDriverProvider = new vr::MyTrackedDeviceProvider();
+        } else {
+            VRDriverLog()->Log("HmdDriverFactory - Returning existing MyTrackedDeviceProvider instance.");
         }
         if (pReturnCode)
             *pReturnCode = vr::VRInitError_None; // Set to None explicitly on success
         return vr::g_pMyDriverProvider;
     }
 
+    VRDriverLog()->Log("HmdDriverFactory - Interface not found: " + std::string(pInterfaceName));
     if (pReturnCode)
         *pReturnCode = vr::VRInitError_Init_InterfaceNotFound;
 

--- a/driver/src/my_controller_driver.cpp
+++ b/driver/src/my_controller_driver.cpp
@@ -1,24 +1,88 @@
 #include "my_controller_driver.h"
+#include "vrcommon/shared/driverlog.h" // For VRDriverLog
+#include <string> // For std::to_string
+
+// Define a preprocessor macro for verbose logging control, e.g., in a common header or at the top of the file
+// #define ENABLE_VERBOSE_CONTROLLER_LOGGING
+
 
 namespace vr {
 
-MyControllerDriver::MyControllerDriver() : m_unObjectId(vr::k_unTrackedDeviceIndexInvalid) {}
+MyControllerDriver::MyControllerDriver()
+    : m_unObjectId(vr::k_unTrackedDeviceIndexInvalid),
+      m_unPhysicalControllerIndex(vr::k_unTrackedDeviceIndexInvalid) {
+#ifdef ENABLE_VERBOSE_CONTROLLER_LOGGING
+  VRDriverLog()->Log("MyControllerDriver::MyControllerDriver - Constructor called.");
+#endif
+  // Initialize m_lastPose to a default disconnected state
+  m_lastPose.poseIsValid = false;
+  m_lastPose.result = vr::TrackingResult_Uninitialized;
+  m_lastPose.deviceIsConnected = false; // Initially false
 
-MyControllerDriver::~MyControllerDriver() {}
+  m_lastPose.qWorldFromDriverRotation = {1.0, 0.0, 0.0, 0.0};
+  m_lastPose.qDriverFromHeadRotation = {1.0, 0.0, 0.0, 0.0};
+
+  for (int i = 0; i < 3; ++i) {
+    m_lastPose.vecPosition[i] = 0.0;
+    m_lastPose.vecVelocity[i] = 0.0;
+    m_lastPose.vecAcceleration[i] = 0.0;
+    m_lastPose.vecAngularVelocity[i] = 0.0;
+    m_lastPose.vecAngularAcceleration[i] = 0.0;
+    m_lastPose.vecWorldFromDriverTranslation[i] = 0.0;
+  }
+  m_lastPose.qRotation = {1.0, 0.0, 0.0, 0.0};
+  m_lastPose.poseTimeOffset = 0.0;
+  // m_lastPose.willDriftInYaw = false; // Already defaults to false
+  // m_lastPose.shouldApplyHeadModel = false; // Already defaults to false
+}
+
+MyControllerDriver::~MyControllerDriver() {
+#ifdef ENABLE_VERBOSE_CONTROLLER_LOGGING
+    VRDriverLog()->Log("MyControllerDriver::~MyControllerDriver - Destructor for ObjectId: " + std::to_string(m_unObjectId));
+#endif
+}
+
+void MyControllerDriver::SetPhysicalControllerIndex(uint32_t index) {
+    VRDriverLog()->Log("MyControllerDriver::SetPhysicalControllerIndex - ObjectId: " + std::to_string(m_unObjectId) + ", PhysicalIndex: " + std::to_string(index));
+    m_unPhysicalControllerIndex = index;
+}
 
 vr::EVRInitError MyControllerDriver::Activate(uint32_t unObjectId) {
-  // Store the object ID
+  VRDriverLog()->Log("MyControllerDriver::Activate - Activating controller with ObjectId: " + std::to_string(unObjectId));
   m_unObjectId = unObjectId;
-  // Initialize properties, etc.
+
+  // Initialize properties or query them from the physical device if necessary
+  // Example: vr::VRProperties()->SetStringProperty(m_ulPropertyContainer, Prop_SerialNumber_String, "my-virtual-controller-123");
+  // Check errors for property settings.
+
+  // When the device is activated, it's considered connected from the driver's perspective.
+  // The actual tracking state (poseIsValid, result) will be updated in RunFrame.
+  m_lastPose.deviceIsConnected = true;
+
+  VRDriverLog()->Log("MyControllerDriver::Activate - Controller activated with ObjectId: " + std::to_string(m_unObjectId));
   return vr::VRInitError_None;
 }
 
 void MyControllerDriver::Deactivate() {
-  // Clean up resources
+  VRDriverLog()->Log("MyControllerDriver::Deactivate - Deactivating controller with ObjectId: " + std::to_string(m_unObjectId));
+  // Clean up resources, if any were allocated in Activate or during operation
+  m_unObjectId = vr::k_unTrackedDeviceIndexInvalid; // Mark as invalid
 }
 
 void MyControllerDriver::EnterStandby() {
-  // Called when the device enters standby mode
+  VRDriverLog()->Log("MyControllerDriver::EnterStandby - Controller with ObjectId: " + std::to_string(m_unObjectId) + " entering standby.");
+  // For a controller, this might mean reducing update rates or preparing for power saving.
+  // The pose should reflect that it's in standby (e.g., poseIsValid = false, result = TrackingResult_Uninitialized).
+  m_lastPose.poseIsValid = false;
+  m_lastPose.result = vr::TrackingResult_Uninitialized;
+  // Keep deviceIsConnected true if it's just standby, or false if it should appear disconnected.
+  // Let's assume it remains connected but not tracking.
+  m_lastPose.deviceIsConnected = true;
+
+  // It's good practice to also inform the host that the pose was updated due to standby.
+  if (m_unObjectId != vr::k_unTrackedDeviceIndexInvalid) {
+      vr::VRServerDriverHost()->TrackedDevicePoseUpdated(m_unObjectId, m_lastPose, sizeof(vr::DriverPose_t));
+  }
 }
 
 void* MyControllerDriver::GetComponent(const char* pchComponentNameAndVersion) {
@@ -34,43 +98,101 @@ void MyControllerDriver::DebugRequest(const char* pchRequest, char* pchResponseB
 }
 
 vr::DriverPose_t MyControllerDriver::GetPose() {
-  // Return the current pose of the controller
-  vr::DriverPose_t pose = {0};
-  pose.poseIsValid = true; // Set to true because we are providing a pose
-  pose.result = vr::TrackingResult_Running_OK;
-  pose.deviceIsConnected = true; // Assume connected
-
-  pose.qWorldFromDriverRotation = {1, 0, 0, 0}; // Identity quaternion
-  pose.qDriverFromHeadRotation = {1, 0, 0, 0};  // Identity quaternion
-  pose.qRotation = {1, 0, 0, 0}; // Identity quaternion
-
-  // Position (example: 0,0,0)
-  pose.vecPosition[0] = 0.0;
-  pose.vecPosition[1] = 0.0;
-  pose.vecPosition[2] = 0.0;
-
-  // Set a default pose (identity)
-  pose.poseTimeOffset = 0.f;
-  pose.vecWorldFromDriverTranslation[0] = 0.f;
-  pose.vecWorldFromDriverTranslation[1] = 0.f;
-  pose.vecWorldFromDriverTranslation[2] = 0.f;
-
-  // Velocity and angular velocity can be zero
-  pose.vecVelocity[0] = 0.f;
-  pose.vecVelocity[1] = 0.f;
-  pose.vecVelocity[2] = 0.f;
-  pose.vecAngularVelocity[0] = 0.f;
-  pose.vecAngularVelocity[1] = 0.f;
-  pose.vecAngularVelocity[2] = 0.f;
-
-  return pose;
+#ifdef ENABLE_VERBOSE_CONTROLLER_LOGGING
+    VRDriverLog()->Log("MyControllerDriver::GetPose - Called for ObjectId: " + std::to_string(m_unObjectId));
+#endif
+  return m_lastPose;
 }
 
 void MyControllerDriver::RunFrame() {
-  if (m_unObjectId != vr::k_unTrackedDeviceIndexInvalid) {
-    vr::DriverPose_t pose = GetPose(); // Get the static pose
-    vr::VRServerDriverHost()->TrackedDevicePoseUpdated(m_unObjectId, pose, sizeof(vr::DriverPose_t));
+#ifdef ENABLE_VERBOSE_CONTROLLER_LOGGING
+    if (m_unObjectId != vr::k_unTrackedDeviceIndexInvalid) { // Avoid logging if not yet activated
+        VRDriverLog()->Log("MyControllerDriver::RunFrame - Called for ObjectId: " + std::to_string(m_unObjectId));
+    }
+#endif
+
+  if (m_unObjectId == vr::k_unTrackedDeviceIndexInvalid) {
+    return; // Not activated yet
   }
+
+  bool physical_pose_retrieved = false;
+  if (m_unPhysicalControllerIndex != vr::k_unTrackedDeviceIndexInvalid) {
+    vr::VRControllerState_t controllerState;
+    if (vr::VRServerDriverHost()->GetControllerState(m_unPhysicalControllerIndex, &controllerState, sizeof(controllerState))) {
+      // Successfully got controller state
+      if (!controllerState.trackedDevicePose.bDeviceIsConnected) {
+#ifdef ENABLE_VERBOSE_CONTROLLER_LOGGING
+          VRDriverLog()->Log("MyControllerDriver::RunFrame - Physical controller (Index: " + std::to_string(m_unPhysicalControllerIndex) + ") for ObjectId: " + std::to_string(m_unObjectId) + " is not connected.");
+#endif
+      }
+      if (!controllerState.trackedDevicePose.bPoseIsValid) {
+#ifdef ENABLE_VERBOSE_CONTROLLER_LOGGING
+          VRDriverLog()->Log("MyControllerDriver::RunFrame - Physical controller (Index: " + std::to_string(m_unPhysicalControllerIndex) + ") for ObjectId: " + std::to_string(m_unObjectId) + " pose is not valid.");
+#endif
+      }
+
+      if (controllerState.trackedDevicePose.bDeviceIsConnected && controllerState.trackedDevicePose.bPoseIsValid) {
+#ifdef ENABLE_VERBOSE_CONTROLLER_LOGGING
+        VRDriverLog()->Log("MyControllerDriver::RunFrame - Valid physical pose found for ObjectId: " + std::to_string(m_unObjectId) + ". Applying to virtual controller.");
+#endif
+        // Copy pose from controllerState.trackedDevicePose (vr::TrackedDevicePose_t) to m_lastPose (vr::DriverPose_t)
+        m_lastPose.poseIsValid = controllerState.trackedDevicePose.bPoseIsValid;
+        m_lastPose.result = controllerState.trackedDevicePose.eTrackingResult;
+        // For the virtual device, its 'deviceIsConnected' status is managed by Activate/Deactivate.
+        // Here, we are interested in the physical device's pose data.
+        // If the physical device disconnects or its pose is invalid, we'll fall into the 'else' block below
+        // to set the virtual device's pose to an untracked state.
+        // However, the m_lastPose.deviceIsConnected should still reflect the *virtual* device's connection state,
+        // which is generally true after Activate() unless Deactivate() or EnterStandby() changes it.
+        // So, we don't directly copy controllerState.trackedDevicePose.bDeviceIsConnected to m_lastPose.deviceIsConnected here.
+        // We ensure m_lastPose.deviceIsConnected is true because the virtual controller is active.
+        m_lastPose.deviceIsConnected = true;
+
+
+        m_lastPose.vecPosition[0] = controllerState.trackedDevicePose.mDeviceToAbsoluteTracking.m[0][3];
+        m_lastPose.vecPosition[1] = controllerState.trackedDevicePose.mDeviceToAbsoluteTracking.m[1][3];
+        m_lastPose.vecPosition[2] = controllerState.trackedDevicePose.mDeviceToAbsoluteTracking.m[2][3];
+
+        m_lastPose.qRotation = controllerState.trackedDevicePose.qRotation;
+
+        m_lastPose.vecVelocity[0] = controllerState.trackedDevicePose.vVelocity.v[0];
+        m_lastPose.vecVelocity[1] = controllerState.trackedDevicePose.vVelocity.v[1];
+        m_lastPose.vecVelocity[2] = controllerState.trackedDevicePose.vVelocity.v[2];
+
+        m_lastPose.vecAngularVelocity[0] = controllerState.trackedDevicePose.vAngularVelocity.v[0];
+        m_lastPose.vecAngularVelocity[1] = controllerState.trackedDevicePose.vAngularVelocity.v[1];
+        m_lastPose.vecAngularVelocity[2] = controllerState.trackedDevicePose.vAngularVelocity.v[2];
+
+        m_lastPose.poseTimeOffset = 0.f;
+        m_lastPose.qWorldFromDriverRotation = {1.0, 0.0, 0.0, 0.0};
+        m_lastPose.vecWorldFromDriverTranslation[0] = 0.0;
+        m_lastPose.vecWorldFromDriverTranslation[1] = 0.0;
+        m_lastPose.vecWorldFromDriverTranslation[2] = 0.0;
+        m_lastPose.qDriverFromHeadRotation = {1.0, 0.0, 0.0, 0.0};
+
+        physical_pose_retrieved = true;
+      }
+    } else {
+        VRDriverLog()->Log("MyControllerDriver::RunFrame - GetControllerState failed for physical controller (Index: " + std::to_string(m_unPhysicalControllerIndex) + ") for ObjectId: " + std::to_string(m_unObjectId));
+    }
+  } else {
+#ifdef ENABLE_VERBOSE_CONTROLLER_LOGGING
+      if (m_unObjectId != vr::k_unTrackedDeviceIndexInvalid) { // Avoid logging if not yet activated
+          VRDriverLog()->Log("MyControllerDriver::RunFrame - ObjectId: " + std::to_string(m_unObjectId) + " has invalid m_unPhysicalControllerIndex. No physical device to track.");
+      }
+#endif
+  }
+
+  if (!physical_pose_retrieved) {
+#ifdef ENABLE_VERBOSE_CONTROLLER_LOGGING
+    VRDriverLog()->Log("MyControllerDriver::RunFrame - ObjectId: " + std::to_string(m_unObjectId) + " - Physical pose not retrieved. Falling back to out_of_range pose.");
+#endif
+    m_lastPose.poseIsValid = false;
+    m_lastPose.result = vr::TrackingResult_Running_OutOfRange;
+    m_lastPose.deviceIsConnected = true; // Virtual device is still connected
+  }
+
+  vr::VRServerDriverHost()->TrackedDevicePoseUpdated(m_unObjectId, m_lastPose, sizeof(vr::DriverPose_t));
 }
 
 }  // namespace vr


### PR DESCRIPTION
…lers

This commit modifies the OpenVR driver to detect connected physical left and right hand controllers and mirror their poses to the driver's virtual controllers.

Key changes:
- `MyTrackedDeviceProvider::Init` now scans for OpenVR controllers with 'LeftHand' and 'RightHand' roles. Virtual controllers are only created if their physical counterparts are found.
- `MyControllerDriver` now stores the device index of the physical controller it's supposed to track.
- `MyControllerDriver::RunFrame` fetches the pose of the assigned physical controller using `GetControllerState` and updates the virtual controller's pose via `TrackedDevicePoseUpdated`.
- If a physical controller isn't available or its pose is invalid, the virtual controller maintains its connection status but indicates an invalid/out-of-range pose.
- `MyControllerDriver::GetPose` now returns the last known pose that `RunFrame` updated, ensuring consistency.
- Added comprehensive logging using `VRDriverLog` for controller detection, pose updates, and potential errors.
- Added error checking for critical OpenVR API calls.